### PR TITLE
Create domain sale landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# forsale
+# Te-koop landingpage
+
+Deze repository bevat een eenvoudige landingspagina voor het verkopen van een domeinnaam. De site is geoptimaliseerd om op meerdere domeinen te worden gebruikt en wordt gepubliceerd via **GitHub Pages** vanuit de map `/docs`.
+
+## Gebruik
+
+1. Zet deze repository op als GitHub Pages-project. Kies daarbij de bron `main` branch en map `/docs`.
+2. Pas eventueel het e‑mailadres aan in `docs/script.js` als `info@<domein>` niet het gewenste adres is.
+3. De bezoeker ziet automatisch de domeinnaam waarop de site wordt gehost en kan via de knop **Doe een bod** een e‑mail sturen met zijn bod.
+
+## Aanpassen
+
+De HTML, CSS en JavaScript staan in de map `docs`. Pas deze bestanden aan om de stijl of teksten naar wens te wijzigen.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Domeinnaam Te Koop</title>
+  <link rel="stylesheet" href="style.css" />
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <div class="container">
+    <h1 id="title">Deze domeinnaam is te koop</h1>
+    <p class="lead">Ben je geïnteresseerd in het aanschaffen van dit adres? Doe hieronder een bod en misschien is het binnenkort van jou!</p>
+    <a id="cta" href="#" class="btn">Doe een bod</a>
+  </div>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const domain = window.location.hostname;
+  const titleEl = document.getElementById('title');
+  const cta = document.getElementById('cta');
+
+  titleEl.textContent = `${domain} is te koop`;
+  const subject = `Bod voor ${domain}`;
+  const body = `Beste verkoper,%0D%0A%0D%0AIk wil graag een bod doen op ${domain}.%0D%0A%0D%0AMijn bod: `;
+  cta.href = `mailto:info@${domain}?subject=${encodeURIComponent(subject)}&body=${body}`;
+});

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,37 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+}
+
+.container {
+  background: white;
+  padding: 2rem;
+  max-width: 500px;
+  text-align: center;
+  border-radius: 8px;
+  box-shadow: 0 0 15px rgba(0,0,0,0.1);
+}
+
+.lead {
+  font-size: 1.2rem;
+}
+
+.btn {
+  background: #007bff;
+  color: #fff;
+  display: inline-block;
+  padding: 0.75rem 1.25rem;
+  margin-top: 1rem;
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background 0.3s ease;
+}
+
+.btn:hover {
+  background: #0056b3;
+}


### PR DESCRIPTION
## Summary
- set up docs folder for GitHub Pages
- add domain sale landing page with HTML/CSS/JS
- add instructions in README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688a722c5aac832fb976c04c4f3d6a71